### PR TITLE
adds Kubernetes Provider and Data Source demo

### DIFF
--- a/kubernetes-data-source/data-sources.tf
+++ b/kubernetes-data-source/data-sources.tf
@@ -1,0 +1,7 @@
+# collect information from the Beacon Service
+data "kubernetes_service" "beacon" {
+  metadata {
+    name      = var.application_name
+    namespace = var.namespace_name
+  }
+}

--- a/kubernetes-data-source/outputs.tf
+++ b/kubernetes-data-source/outputs.tf
@@ -1,0 +1,22 @@
+# assign application data to local variables for easier re-use
+locals {
+  application_host = data.kubernetes_service.beacon.load_balancer_ingress[0].hostname
+  application_port = data.kubernetes_service.beacon.spec[0].port[0].port
+}
+
+# uncomment this to display the full Service data object
+#output "application_service_data" {
+#  value = data.kubernetes_service.beacon
+#}
+
+output "application_host" {
+  value = local.application_host
+}
+
+output "application_port" {
+  value = local.application_port
+}
+
+output "application_url" {
+  value = "http://${local.application_host}:${local.application_port}"
+}

--- a/kubernetes-data-source/terraform.tf
+++ b/kubernetes-data-source/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "1.13.3"
+    }
+  }
+}
+
+# see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started#provider-setup for more information
+provider "kubernetes" {
+  # load Kubernetes Cluster configuration from `~/.kubectl/config` as opposed to manually
+  # configuring `host`, `client_certificate`, `client_key`, and `cluster_ca_certificate`.
+  load_config_file = true
+}

--- a/kubernetes-data-source/variables.tf
+++ b/kubernetes-data-source/variables.tf
@@ -1,0 +1,17 @@
+variable "namespace_name" {
+  type        = string
+  description = "Namespace Name"
+  default     = "beacon"
+}
+
+variable "application_name" {
+  type        = string
+  description = "Application Name"
+  default     = "beacon"
+}
+
+variable "application_port" {
+  type        = number
+  description = "Application Port"
+  default     = 8080
+}

--- a/kubernetes/deployment.tf
+++ b/kubernetes/deployment.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_deployment" "beacon" {
+  metadata {
+    name      = var.application_name
+    namespace = kubernetes_namespace.beacon.id
+    labels = {
+      app = var.application_name
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = var.application_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = var.application_name
+        }
+      }
+
+      spec {
+        container {
+          image = "onlydole/beacon:1.19.1"
+          name  = var.application_name
+        }
+      }
+    }
+  }
+}

--- a/kubernetes/namespace.tf
+++ b/kubernetes/namespace.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "beacon" {
+  metadata {
+    name = var.namespace_name
+  }
+}

--- a/kubernetes/service.tf
+++ b/kubernetes/service.tf
@@ -1,0 +1,19 @@
+resource "kubernetes_service" "beacon" {
+  metadata {
+    name      = var.application_name
+    namespace = kubernetes_namespace.beacon.id
+  }
+
+  spec {
+    selector = {
+      app = kubernetes_deployment.beacon.metadata[0].labels.app
+    }
+
+    port {
+      port        = var.application_port
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}

--- a/kubernetes/terraform.tf
+++ b/kubernetes/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "1.13.3"
+    }
+  }
+}
+
+# see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started#provider-setup for more information
+provider "kubernetes" {
+  # load Kubernetes Cluster configuration from `~/.kubectl/config` as opposed to manually
+  # configuring `host`, `client_certificate`, `client_key`, and `cluster_ca_certificate`.
+  load_config_file = true
+}

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -1,0 +1,17 @@
+variable "namespace_name" {
+  type        = string
+  description = "Namespace Name"
+  default     = "beacon"
+}
+
+variable "application_name" {
+  type        = string
+  description = "Application Name"
+  default     = "beacon"
+}
+
+variable "application_port" {
+  type        = number
+  description = "Application Port"
+  default     = 8080
+}

--- a/yaml/service.yaml
+++ b/yaml/service.yaml
@@ -9,5 +9,4 @@ spec:
   ports:
     - port: 8081
       targetPort: 80
-  externalTrafficPolicy: Local
   type: LoadBalancer


### PR DESCRIPTION
This PR adds the default Kubernetes Provider and a secondary directory with a data source demo.

The Data Source is kept apart from the main code to allow for demoing how to use read-only resources, only.